### PR TITLE
[pickle] Dump using the highest available protocol

### DIFF
--- a/flask_caching/backends/memcache.py
+++ b/flask_caching/backends/memcache.py
@@ -327,7 +327,7 @@ class SpreadSASLMemcachedCache(SASLMemcachedCache):
         # I didn't found a good way to avoid pickling/unpickling if
         # key is smaller than chunksize, because in case or <werkzeug.requests>
         # getting the length consume the data iterator.
-        serialized = pickle.dumps(value, 2)
+        serialized = pickle.dumps(value, pickle.HIGHEST_PROTOCOL)
         values = {}
         len_ser = len(serialized)
         chks = range(0, len_ser, self.chunksize)

--- a/flask_caching/backends/rediscache.py
+++ b/flask_caching/backends/rediscache.py
@@ -123,7 +123,7 @@ class RedisCache(BaseCache):
         t = type(value)
         if t == int:
             return str(value).encode("ascii")
-        return b"!" + pickle.dumps(value)
+        return b"!" + pickle.dumps(value, pickle.HIGHEST_PROTOCOL)
 
     def load_object(self, value):
         """The reversal of :meth:`dump_object`.  This might be called with

--- a/flask_caching/contrib/googlecloudstoragecache.py
+++ b/flask_caching/contrib/googlecloudstoragecache.py
@@ -102,7 +102,7 @@ class GoogleCloudStorageCache(BaseCache):
         full_key = self.key_prefix + key
         content_type = "application/json"
         try:
-            value = json.dumps(value)
+            value = json.dumps(value, pickle.HIGHEST_PROTOCOL)
         except (UnicodeDecodeError, TypeError):
             content_type = "application/octet-stream"
         blob = self.bucket.blob(full_key)

--- a/flask_caching/contrib/googlecloudstoragecache.py
+++ b/flask_caching/contrib/googlecloudstoragecache.py
@@ -102,7 +102,7 @@ class GoogleCloudStorageCache(BaseCache):
         full_key = self.key_prefix + key
         content_type = "application/json"
         try:
-            value = json.dumps(value, pickle.HIGHEST_PROTOCOL)
+            value = json.dumps(value)
         except (UnicodeDecodeError, TypeError):
             content_type = "application/octet-stream"
         blob = self.bucket.blob(full_key)

--- a/flask_caching/contrib/uwsgicache.py
+++ b/flask_caching/contrib/uwsgicache.py
@@ -83,7 +83,7 @@ class UWSGICache(BaseCache):
     def set(self, key, value, timeout=None):
         return self._uwsgi.cache_update(
             key,
-            pickle.dumps(value),
+            pickle.dumps(value, pickle.HIGHEST_PROTOCOL),
             self._normalize_timeout(timeout),
             self.cache,
         )
@@ -91,7 +91,7 @@ class UWSGICache(BaseCache):
     def add(self, key, value, timeout=None):
         return self._uwsgi.cache_set(
             key,
-            pickle.dumps(value),
+            pickle.dumps(value, pickle.HIGHEST_PROTOCOL),
             self._normalize_timeout(timeout),
             self.cache,
         )


### PR DESCRIPTION
This PR ensures that all backends use the same protocol (the highest available) for pickling the payload to cache. Some backends currently use the default (4 for Python 3.8) whereas some use 2 and others use the highest protocol available (maximum of 5). 

Per the `pickle` [documentation](https://docs.python.org/3/library/pickle.html#data-stream-format),

> Protocol version 5 was added in Python 3.8. It adds support for out-of-band data and speedup for in-band data. Refer to PEP 574 for information about improvements brought by protocol 5.

it seems there is merit in utilizing the highest available protocol for consistency and increased performance.

Note that it seems the protocol is encoded within the dumped object, i.e., one does not need to re-specify the protocol when loading via `pickle.loads(...)`, thus this should be a non-breaking change. 
 