### PR TITLE
update supported Python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, pypy-3.7]
+        python-version: [3.6, 3.7, 3.8, 3.9, pypy-3.7]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.6 was missing for gh actions.