### PR TITLE
Extensible serializers support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -350,6 +350,18 @@ The following configuration values exist for Flask-Caching:
 ``CACHE_DEFAULT_TIMEOUT``       The default timeout that is used if no
                                 timeout is specified. Unit of time is
                                 seconds.
+``CACHE_SERIALIZER``            Pickle-like serialization implementation.
+                                It should support load(-s) and dump(-s)
+                                methods and binary strings/files. May be
+                                object, import string or predefined
+                                implementation name (``"json"`` or
+                                ``"pickle"``). Defaults to "pickle", but
+                                pickle module is not secure (CVE-2021-33026).
+                                Consider using another serializer (eg. JSON).
+``CACHE_SERIALIZER_ERROR``      Deserialization error. May be object,
+                                import string or predefined error name
+                                (``"JSONError"`` or ``"PickleError"``).
+                                Defaults to ``"PickleError"``.
 ``CACHE_IGNORE_ERRORS``         If set to any errors that occurred during the
                                 deletion process will be ignored. However, if
                                 it is set to ``False`` it will stop on the

--- a/src/flask_caching/backends/base.py
+++ b/src/flask_caching/backends/base.py
@@ -11,6 +11,34 @@
 """
 from cachelib import BaseCache as CachelibBaseCache
 
+from flask_caching.serialization import pickle, PickleError
+import warnings
+
+def iteritems_wrapper(mappingorseq):
+    """Wrapper for efficient iteration over mappings represented by dicts
+    or sequences::
+
+        >>> for k, v in iteritems_wrapper((i, i*i) for i in xrange(5)):
+        ...    assert k*k == v
+
+        >>> for k, v in iteritems_wrapper(dict((i, i*i) for i in xrange(5))):
+        ...    assert k*k == v
+
+    """
+    if hasattr(mappingorseq, "items"):
+        return mappingorseq.items()
+    return mappingorseq
+
+
+def extract_serializer_args(data):
+    result = dict()
+    serializer_prefix = "serializer_"
+    for key in tuple(data.keys()):
+        if key.startswith(serializer_prefix):
+            result[key] = data.pop(key)
+    return result
+
+
 
 class BaseCache(CachelibBaseCache):
     """Baseclass for the cache systems.  All the cache systems implement this
@@ -19,11 +47,35 @@ class BaseCache(CachelibBaseCache):
     :param default_timeout: The default timeout (in seconds) that is used if
                             no timeout is specified on :meth:`set`. A timeout
                             of 0 indicates that the cache never expires.
+    :param serializer_impl: Pickle-like serialization implementation. It should
+                            support load(-s) and dump(-s) methods and binary
+                            strings/files.
+    :param serializer_error: Deserialization exception - for specified
+                             implementation.
     """
 
-    def __init__(self, default_timeout=300):
-        CachelibBaseCache.__init__(self, default_timeout=default_timeout)
+    def __init__(
+        self,
+        default_timeout=300,
+        serializer_impl=pickle,
+        serializer_error=PickleError
+    ):
+        CachelibBaseCache.__init__(
+            self,
+            default_timeout=default_timeout
+        )
+
+        self.default_timeout = default_timeout
         self.ignore_errors = False
+
+        if serializer_impl is pickle:
+            warnings.warn(
+                "Pickle serializer is not secure and may "
+                "lead to remote code execution. "
+                "Consider using another serializer (eg. JSON)."
+            )
+        self._serializer = serializer_impl
+        self._serialization_error = serializer_error
 
     @classmethod
     def factory(cls, app, config, args, kwargs):

--- a/src/flask_caching/serialization.py
+++ b/src/flask_caching/serialization.py
@@ -1,0 +1,34 @@
+import json as _json
+try:
+    import cPickle as pickle
+except ImportError:  # pragma: no cover
+    import pickle  # type: ignore
+
+
+class BytesSerializer:
+    """Serializer wrapper with auto str2bytes casting"""
+    def __init__(self, serializer):
+        self._serializer = serializer
+
+    def dumps(self, obj, *args, **kwargs):
+        result = self._serializer.dumps(obj, *args, **kwargs)
+        if isinstance(result, str):
+            return result.encode()
+        return result
+
+    def dump(self, obj, fp, *args, **kwargs):
+        fp.write(self.dumps(obj, *args, **kwargs))
+
+    def loads(self, obj, *args, **kwargs):
+        if isinstance(obj, bytes):
+            obj = obj.decode()
+        return self._serializer.loads(obj, *args, **kwargs)
+
+    def load(self, fp, *args, **kwargs):
+        return self.loads(fp.read(), *args, **kwargs)
+
+
+json = BytesSerializer(_json)
+JSONError = _json.JSONDecodeError
+
+PickleError = pickle.PickleError


### PR DESCRIPTION
Since https://github.com/pallets-eco/flask-caching/pull/209 appears waiting on conflicts being merged, I thought I would work through the merge conflicts as I want to use this for a project. Unfortunately, what's stopping me is #209.

All the tests are passing. This is a merge of pallets-eco/master with subnix:feature/extensible-serializer and conflicts resolved.

Have also tested it with a working application. I have also debugged through and confirmed the serializer can be changed to JSON and also no longer accepts objects like "Response" (e.g. trying to apply the cache to a function which returns response.response) because they cannot be serialised to JSON.