### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,28 +2,28 @@ ci:
   autoupdate_schedule: monthly
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.25.0
+    rev: v2.32.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.6.0
+    rev: v3.0.1
     hooks:
       - id: reorder-python-imports
         args: ["--application-directories", "src"]
   - repo: https://github.com/psf/black
-    rev: 21.8b0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-bugbear
           - flake8-implicit-str-concat
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.2.0
     hooks:
       - id: fix-byte-order-marker
       - id: trailing-whitespace


### PR DESCRIPTION
There seems to be a problem with pre-commit hooks which is fixed by black 22.3.0

```
Traceback (most recent call last):
  File "/root/.cache/pre-commit/repotslw8qcx/py_env-python3.7/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/root/.cache/pre-commit/repotslw8qcx/py_env-python3.7/lib/python3.7/site-packages/black/__init__.py", line 1282, in patched_main
    patch_click()
  File "/root/.cache/pre-commit/repotslw8qcx/py_env-python3.7/lib/python3.7/site-packages/black/__init__.py", line 1268, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/root/.cache/pre-commit/repotslw8qcx/py_env-python3.7/lib/python3.7/site-packages/click/__init__.py)
```
