### PR TITLE
Fixes #343 bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Unreleased
 - Cachelib is now used as backend. PR `#308 <https://github.com/pallets-eco/flask-caching/pull/308>`_.
 - Drop support for python 3.6. PR `#332 <https://github.com/pallets-eco/flask-caching/pull/332>`_.
 - Add support for dynamic cache timeouts `#296 <https://github.com/pallets-eco/flask-caching/pull/296>`_.
-
+- Fix bug `#343 <https://github.com/pallets-eco/flask-caching/issues/343>`_ in CACHE_OPTIONS reading for radis in RedisSentinelCache
 
 Version 1.10.1
 --------------

--- a/src/flask_caching/backends/rediscache.py
+++ b/src/flask_caching/backends/rediscache.py
@@ -168,7 +168,7 @@ class RedisSentinelCache(RedisCache):
             if key.startswith("sentinel_")
         }
         kwargs = {
-            key[9:]: value
+            key: value
             for key, value in kwargs.items()
             if not key.startswith("sentinel_")
         }


### PR DESCRIPTION
It was wrong parsing not _sentinel__ CACHE_OPTIONS in RedisSentinelCache

- fixes #343 

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [X] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
