### PR TITLE
release 11.0.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+
 Version 1.11.0
 --------------
 
@@ -11,7 +12,8 @@ Released 2022-05-27
 - Cachelib is now used as backend. PR `#308 <https://github.com/pallets-eco/flask-caching/pull/308>`_.
 - Drop support for python 3.6. PR `#332 <https://github.com/pallets-eco/flask-caching/pull/332>`_.
 - Add support for dynamic cache timeouts `#296 <https://github.com/pallets-eco/flask-caching/pull/296>`_.
-- Fix bug `#343 <https://github.com/pallets-eco/flask-caching/issues/343>`_ in CACHE_OPTIONS reading for radis in RedisSentinelCache
+- Fix bug in ``CACHE_OPTIONS`` reading for redis in ``RedisSentinelCache``. PR `#343 <https://github.com/pallets-eco/flask-caching/issues/343>`_.
+
 
 Version 1.10.1
 --------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 Version 1.11.0
 --------------
 
-Unreleased
+Released 2022-05-27
 
 - Add suport for cached/memoized generators. PR `#286 <https://github.com/pallets-eco/flask-caching/pull/286>`_.
 - Add support for Flask 2.0 async. PR `#282 <https://github.com/pallets-eco/flask-caching/pull/282>`_.

--- a/src/flask_caching/__init__.py
+++ b/src/flask_caching/__init__.py
@@ -38,7 +38,7 @@ from flask_caching.utils import get_id
 from flask_caching.utils import make_template_fragment_key  # noqa: F401
 from flask_caching.utils import wants_args
 
-__version__ = "1.10.1"
+__version__ = "1.11.0"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Our 1.11.0 release 🎉 

**Change summary**

- Add suport for cached/memoized generators. PR `#286 <https://github.com/pallets-eco/flask-caching/pull/286>`_.
- Add support for Flask 2.0 async. PR `#282 <https://github.com/pallets-eco/flask-caching/pull/282>`_.
- Cachelib is now used as backend. PR `#308 <https://github.com/pallets-eco/flask-caching/pull/308>`_.
- Drop support for python 3.6. PR `#332 <https://github.com/pallets-eco/flask-caching/pull/332>`_.
- Add support for dynamic cache timeouts `#296 <https://github.com/pallets-eco/flask-caching/pull/296>`_.
- Fix bug in CACHE_OPTIONS reading for radis in RedisSentinelCache
