### PR TITLE
requirements: Add cachelib dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 # Metadata goes in setup.cfg. These are here for GitHub's dependency graph.
 setup(
     name="Flask-Caching",
-    install_requires=["Flask"],
+    install_requires=["cachelib", "Flask"],
     tests_require=[
         "pytest",
         "pytest-xprocess",


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->
Since #308 added a hard requirement for `cachelib`, add it to user-facing `setup.py` as well (it was previously only added to dev-dependencies).

I'm not gonna run this whole test suite, sorry. You pushed a broken release 0.11.0, please phixit ;)

To avoid similar issues in the future, it would probably be better to put non-dev requirements into `requirements/prod.in` and generate regular `requirements.txt` from that. Also remove `cachelib` and other non-test deps from `test.in` and instead `-r prod.in`. But that's for you to decide. 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

--- 

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
