### PR TITLE
Fix type annotation errors in Cache

### DIFF
--- a/src/flask_caching/__init__.py
+++ b/src/flask_caching/__init__.py
@@ -193,7 +193,7 @@ class Cache:
         """Proxy function for internal cache object."""
         return self.cache.has(*args, **kwargs)
 
-    def set(self, *args, **kwargs) -> bool:
+    def set(self, *args, **kwargs) -> Optional[bool]:
         """Proxy function for internal cache object."""
         return self.cache.set(*args, **kwargs)
 
@@ -209,7 +209,7 @@ class Cache:
         """Proxy function for internal cache object."""
         return self.cache.delete_many(*args, **kwargs)  # type: ignore
 
-    def clear(self) -> None:
+    def clear(self) -> bool:
         """Proxy function for internal cache object."""
         return self.cache.clear()
 


### PR DESCRIPTION
Fix type annotations in the `Cache` class as pointed out by mypy.

- See #384 (this PR alone does not fix it completely)

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
