### PR TITLE
Relax Flask version restriction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Version 2.0.1
+-------------
+
+Unreleased
+
+- Relax dependency pin to allow Flask 2.x.x
+
+
 Version 2.0.0
 -------------
 

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ from setuptools import setup
 # Metadata goes in setup.cfg. These are here for GitHub's dependency graph.
 setup(
     name="Flask-Caching",
-    install_requires=["cachelib >= 0.9.0", "Flask <= 2.1.2"],
+    install_requires=["cachelib >= 0.9.0", "Flask < 2.2.0"],
 )

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ from setuptools import setup
 # Metadata goes in setup.cfg. These are here for GitHub's dependency graph.
 setup(
     name="Flask-Caching",
-    install_requires=["cachelib >= 0.9.0", "Flask < 2.2.0"],
+    install_requires=["cachelib >= 0.9.0", "Flask < 3"],
 )


### PR DESCRIPTION
... to minor version that's compatible

- [x] add changelog entry
- [x] relax Flask pin in setup.py to allow 2.x.x

fix #388 #382