### PR TITLE
release 2.0.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 Version 2.0.1
 -------------
 
-Unreleased
+Released 2022-07-30
 
 - Relax dependency pin to allow Flask 2.x.x
 

--- a/src/flask_caching/__init__.py
+++ b/src/flask_caching/__init__.py
@@ -38,7 +38,7 @@ from flask_caching.utils import get_id
 from flask_caching.utils import make_template_fragment_key  # noqa: F401
 from flask_caching.utils import wants_args
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Our 2.0.1 release 🎉 

**Change summary:**

- Relax dependency pin to allow Flask 2.x.x 