### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -616,8 +616,8 @@ Set ``CACHE_TYPE`` to ``SpreadSASLMemcachedCache`` to use this type.  The old
 name, ``spreadsaslmemcached`` is deprecated and will be removed in
 Flask-Caching 2.0.
 
-Same as SASLMemcachedCache however, it has the ablity to spread value across
-multiple keys if it is bigger than the memcached treshold which by
+Same as SASLMemcachedCache however, it has the ability to spread value across
+multiple keys if it is bigger than the memcached threshold which by
 default is 1M. Uses pickle.
 
 .. versionadded:: 0.11

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -471,7 +471,7 @@ def test_cache_with_query_string_and_source_check_enabled(app, cache):
     def view_works():
         return str(time.time())
 
-    # ... and we overide the function attached to the view
+    # ... and we override the function attached to the view
     app.view_functions["works"] = view_works
 
     tc = app.test_client()
@@ -534,7 +534,7 @@ def test_cache_with_query_string_and_source_check_disabled(app, cache):
     def view_works():
         return str(time.time())
 
-    # ... and we overide the function attached to the view
+    # ... and we override the function attached to the view
     app.view_functions["works"] = view_works
 
     tc = app.test_client()


### PR DESCRIPTION
There are small typos in:
- docs/index.rst
- tests/test_view.py

Fixes:
- Should read `threshold` rather than `treshold`.
- Should read `override` rather than `overide`.
- Should read `ability` rather than `ablity`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md