### PR TITLE
Feature/update rediscluster cache dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 2.0.2
+-------------
+
+- migrate ``flask_caching.backends.RedisCluster`` dependency from redis-py-cluster to redis-py
+
 Version 2.0.1
 -------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -353,8 +353,8 @@ The following configuration values exist for Flask-Caching:
                                   **redis**)
                                 * **RedisSentinelCache** (redis required; old
                                   name is **redissentinel**)
-                                * **RedisClusterCache** (redis and rediscluster
-                                  required; old name is **rediscluster**)
+                                * **RedisClusterCache** (redis required; old
+                                  name is **rediscluster**)
                                 * **UWSGICache** (uwsgi required; old name is
                                   **uwsgi**)
                                 * **MemcachedCache** (pylibmc or memcache

--- a/src/flask_caching/backends/rediscache.py
+++ b/src/flask_caching/backends/rediscache.py
@@ -230,14 +230,15 @@ class RedisClusterCache(RedisCache):
             raise ValueError("decode_responses is not supported by RedisCache.")
 
         try:
-            from rediscluster import RedisCluster
+            from redis import RedisCluster
+            from redis.cluster import ClusterNode
         except ImportError as e:
-            raise RuntimeError("no rediscluster module found") from e
+            raise RuntimeError("no redis.cluster module found") from e
 
         try:
             nodes = [(node.split(":")) for node in cluster.split(",")]
             startup_nodes = [
-                {"host": node[0].strip(), "port": node[1].strip()} for node in nodes
+                ClusterNode(node[0].strip(), node[1].strip()) for node in nodes
             ]
         except IndexError as e:
             raise ValueError(

--- a/src/flask_caching/utils.py
+++ b/src/flask_caching/utils.py
@@ -1,7 +1,7 @@
 import inspect
 import string
-
-from typing import Callable, List
+from typing import Callable
+from typing import List
 
 TEMPLATE_FRAGMENT_KEY_TEMPLATE = "_template_fragment_cache_%s%s"
 # Used to remove control characters and whitespace from cache keys.
@@ -93,16 +93,16 @@ def function_namespace(f, args=None):
 
     ns = ".".join((module, name)).translate(*null_control)
 
-    ins = ".".join((module, name, instance_token)) \
-        .translate(*null_control) if instance_token else None
+    ins = (
+        ".".join((module, name, instance_token)).translate(*null_control)
+        if instance_token
+        else None
+    )
 
     return ns, ins
 
 
-def make_template_fragment_key(
-    fragment_name: str,
-    vary_on: List[str] = None
-) -> str:
+def make_template_fragment_key(fragment_name: str, vary_on: List[str] = None) -> str:
     """Make a cache key for a specific fragment name."""
     if vary_on:
         fragment_name = "%s_" % fragment_name

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -316,7 +316,7 @@ def test_cache_forced_update_params(app, cache):
 
 
 def test_generator(app, cache):
-    """ test function return generator"""
+    """test function return generator"""
     with app.test_request_context():
 
         @cache.cached()

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -37,7 +37,7 @@ def test_cached_view_class(app, cache):
         def dispatch_request(self):
             return str(time.time())
 
-    app.add_url_rule("/", view_func=CachedView.as_view('name'))
+    app.add_url_rule("/", view_func=CachedView.as_view("name"))
 
     tc = app.test_client()
 
@@ -55,7 +55,7 @@ def test_cached_view_class(app, cache):
     rv = tc.get("/")
     assert the_time != rv.data.decode("utf-8")
 
-    
+
 def test_async_cached_view(app, cache):
     import asyncio
     import sys
@@ -74,11 +74,11 @@ def test_async_cached_view(app, cache):
     the_time = rv.data.decode("utf-8")
 
     time.sleep(1)
-    
+
     rv = tc.get("/test-async")
     assert the_time == rv.data.decode("utf-8")
 
-    
+
 def test_cached_view_unless(app, cache):
     @app.route("/a")
     @cache.cached(5, unless=lambda: True)


### PR DESCRIPTION
redis-py-cluster EOL, this library extends ported to redis-py since version 4.1.0. RedisCluster backend in flask-caching rediscache should use the RedisCluster in redis-py.

- fixes #398

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
