### PR TITLE
bug fix: make cached view function make_cache_key attr writeable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 2.0.2
 -------------
 
 - migrate ``flask_caching.backends.RedisCluster`` dependency from redis-py-cluster to redis-py
+- bug fix: make the ``make_cache_key`` attributed of decorated view functions writeable. :pr:`431`, issue `#97`
 
 Version 2.0.1
 -------------

--- a/src/flask_caching/__init__.py
+++ b/src/flask_caching/__init__.py
@@ -363,7 +363,7 @@ class Cache:
                     if make_cache_key is not None and callable(make_cache_key):
                         cache_key = make_cache_key(*args, **kwargs)
                     else:
-                        cache_key = _make_cache_key(args, kwargs, use_request=True)
+                        cache_key = decorated_function.make_cache_key(*args, use_request=True, **kwargs)
 
                     if (
                         callable(forced_update)
@@ -430,7 +430,8 @@ class Cache:
                 for arg_name, arg in zip(argspec_args, args):
                     kwargs[arg_name] = arg
 
-                return _make_cache_key(args, kwargs, use_request=False)
+                use_request = kwargs.pop('use_request', False)
+                return _make_cache_key(args, kwargs, use_request=use_request)
 
             def _make_cache_key_query_string():
                 """Create consistent keys for query string arguments.

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -211,6 +211,33 @@ def test_cache_key_property(app, cache):
         assert the_time == cache_data
 
 
+def test_set_make_cache_key_property(app, cache):
+    @app.route("/")
+    @cache.cached(5)
+    def cached_view():
+        return str(time.time())
+
+    cached_view.make_cache_key = lambda *args, **kwargs: request.args['foo']
+
+    tc = app.test_client()
+
+    rv = tc.get("/?foo=a")
+    a = rv.data.decode("utf-8")
+
+    rv = tc.get("/?foo=b")
+    b = rv.data.decode("utf-8")
+    assert a != b
+
+    tc = app.test_client()
+    rv = tc.get("/?foo=a")
+    a_2 = rv.data.decode("utf-8")
+    assert a == a_2
+
+    rv = tc.get("/?foo=b")
+    b_2 = rv.data.decode("utf-8")
+    assert b == b_2
+
+
 def test_make_cache_key_function_property(app, cache):
     @app.route("/<foo>/<bar>")
     @cache.memoize(5)


### PR DESCRIPTION
fixes #97. this matches how memoize already does the same thing:

https://github.com/pallets-eco/flask-caching/blob/b526e03edf0602d10d9cf938b955a59b521636ad/src/flask_caching/__init__.py#L838

<!--
Before opening a PR, open a ticket describing the issue or feature the PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- N/A Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- N/A Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
