### PR TITLE
Pin cachelib to previous release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ from setuptools import setup
 # Metadata goes in setup.cfg. These are here for GitHub's dependency graph.
 setup(
     name="Flask-Caching",
-    install_requires=["cachelib >= 0.9.0", "Flask < 3"],
+    install_requires=["cachelib >= 0.9.0, < 0.10.0", "Flask < 3"],
 )


### PR DESCRIPTION
As of now flask-caching doesn't support latest cachelib release where DynamoDB backend has been added, for now I'll go ahead and pin cachelib to < 0.10.0 until I get around to make the necessary changes to allow for the use of the new backend.