### PR TITLE
Release 2.0.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
           - {name: Linux, python: '3.9', os: ubuntu-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
+          - {name: '3.10', python: '3.10', os: ubuntu-latest, tox: py310}
           - {name: 'PyPy', python: pypy-3.7, os: ubuntu-latest, tox: pypy37}
           - {name: 'mypy', python: '3.9', os: ubuntu-latest, tox: typing}
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 Version 2.0.2
 -------------
 
+Released 2023-01-12
+
+- fix issue with boto3 dependencie due to latest cachelib released
 - migrate ``flask_caching.backends.RedisCluster`` dependency from redis-py-cluster to redis-py
 - bug fix: make the ``make_cache_key`` attributed of decorated view functions writeable. :pr:`431`, issue `#97`
 

--- a/src/flask_caching/__init__.py
+++ b/src/flask_caching/__init__.py
@@ -38,7 +38,7 @@ from flask_caching.utils import get_id
 from flask_caching.utils import make_template_fragment_key  # noqa: F401
 from flask_caching.utils import wants_args
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 logger = logging.getLogger(__name__)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,38,37,py3}
+    py{39,38,37,py3,310}
     style
     typing
     docs


### PR DESCRIPTION
Our 2.0.2 released 🎉 

This is a hotfix release to address issues with latest cachelib.

**Change Summary**

- avoid issue with `boto3` dependency on flask_caching import due to latest cachelib released 
- migrate ``flask_caching.backends.RedisCluster`` dependency from redis-py-cluster to redis-py
- bug fix: make the ``make_cache_key`` attributed of decorated view functions writeable. :pr:`431`, issue `#97`