### PR TITLE
Use delete_many from cachelib. Remove CACHE_IGNORE_ERRORS flag.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -375,12 +375,6 @@ The following configuration values exist for Flask-Caching:
 ``CACHE_DEFAULT_TIMEOUT``       The default timeout that is used if no
                                 timeout is specified. Unit of time is
                                 seconds.
-``CACHE_IGNORE_ERRORS``         If set to any errors that occurred during the
-                                deletion process will be ignored. However, if
-                                it is set to ``False`` it will stop on the
-                                first error. This option is only relevant for
-                                the backends **filesystem** and **simple**.
-                                Defaults to ``False``.
 ``CACHE_THRESHOLD``             The maximum number of items the cache
                                 will store before it starts deleting
                                 some. Used only for SimpleCache and
@@ -461,7 +455,6 @@ Uses a local python dictionary for caching. This is not really thread safe.
 Relevant configuration values
 
 - CACHE_DEFAULT_TIMEOUT
-- CACHE_IGNORE_ERRORS
 - CACHE_THRESHOLD
 
 .. versionchanged::  1.9.1
@@ -477,7 +470,6 @@ Set ``CACHE_TYPE`` to ``FileSystemCache`` to use this type.  The old name,
 Uses the filesystem to store cached values
 
 - CACHE_DEFAULT_TIMEOUT
-- CACHE_IGNORE_ERRORS
 - CACHE_DIR
 - CACHE_THRESHOLD
 - CACHE_OPTIONS

--- a/src/flask_caching/__init__.py
+++ b/src/flask_caching/__init__.py
@@ -104,7 +104,6 @@ class Cache:
         config = base_config
 
         config.setdefault("CACHE_DEFAULT_TIMEOUT", 300)
-        config.setdefault("CACHE_IGNORE_ERRORS", False)
         config.setdefault("CACHE_THRESHOLD", 500)
         config.setdefault("CACHE_KEY_PREFIX", "flask_cache_")
         config.setdefault("CACHE_MEMCACHED_SERVERS", None)

--- a/src/flask_caching/__init__.py
+++ b/src/flask_caching/__init__.py
@@ -362,7 +362,9 @@ class Cache:
                     if make_cache_key is not None and callable(make_cache_key):
                         cache_key = make_cache_key(*args, **kwargs)
                     else:
-                        cache_key = decorated_function.make_cache_key(*args, use_request=True, **kwargs)
+                        cache_key = decorated_function.make_cache_key(
+                            *args, use_request=True, **kwargs
+                        )
 
                     if (
                         callable(forced_update)
@@ -429,7 +431,7 @@ class Cache:
                 for arg_name, arg in zip(argspec_args, args):
                     kwargs[arg_name] = arg
 
-                use_request = kwargs.pop('use_request', False)
+                use_request = kwargs.pop("use_request", False)
                 return _make_cache_key(args, kwargs, use_request=use_request)
 
             def _make_cache_key_query_string():

--- a/src/flask_caching/backends/base.py
+++ b/src/flask_caching/backends/base.py
@@ -2,46 +2,20 @@
     flask_caching.backends.base
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    This module contains the BaseCache that other caching
+    This module contains the BaseFactory that other caching
     backends have to implement.
 
     :copyright: (c) 2018 by Peter Justin.
     :copyright: (c) 2010 by Thadeus Burgess.
     :license: BSD, see LICENSE for more details.
 """
-from cachelib import BaseCache as CachelibBaseCache
 
 
-class BaseCache(CachelibBaseCache):
-    """Baseclass for the cache systems.  All the cache systems implement this
+class BaseFactory:
+    """Baseclass for the cache systems. All the cache systems implement this
     API or a superset of it.
-
-    :param default_timeout: The default timeout (in seconds) that is used if
-                            no timeout is specified on :meth:`set`. A timeout
-                            of 0 indicates that the cache never expires.
     """
-
-    def __init__(self, default_timeout=300):
-        CachelibBaseCache.__init__(self, default_timeout=default_timeout)
-        self.ignore_errors = False
 
     @classmethod
     def factory(cls, app, config, args, kwargs):
         return cls()
-
-    def delete_many(self, *keys):
-        """Deletes multiple keys at once.
-
-        :param keys: The function accepts multiple keys as positional
-                        arguments.
-        :returns: A list containing all sucessfuly deleted keys
-        :rtype: boolean
-        """
-        deleted_keys = []
-        for key in keys:
-            if self.delete(key):
-                deleted_keys.append(key)
-            else:
-                if not self.ignore_errors:
-                    break
-        return deleted_keys

--- a/src/flask_caching/backends/filesystemcache.py
+++ b/src/flask_caching/backends/filesystemcache.py
@@ -51,7 +51,6 @@ class FileSystemCache(BaseFactory, CachelibFileSystemCache):
         hash_method=hashlib.md5,
         ignore_errors=False,
     ):
-
         CachelibFileSystemCache.__init__(
             self,
             cache_dir=cache_dir,

--- a/src/flask_caching/backends/filesystemcache.py
+++ b/src/flask_caching/backends/filesystemcache.py
@@ -13,12 +13,12 @@ import logging
 
 from cachelib import FileSystemCache as CachelibFileSystemCache
 
-from flask_caching.backends.base import BaseCache
+from flask_caching.backends.base import BaseFactory
 
 logger = logging.getLogger(__name__)
 
 
-class FileSystemCache(BaseCache, CachelibFileSystemCache):
+class FileSystemCache(BaseFactory, CachelibFileSystemCache):
 
     """A cache that stores the items on the file system.  This cache depends
     on being the only user of the `cache_dir`.  Make absolutely sure that
@@ -52,7 +52,6 @@ class FileSystemCache(BaseCache, CachelibFileSystemCache):
         ignore_errors=False,
     ):
 
-        BaseCache.__init__(self, default_timeout=default_timeout)
         CachelibFileSystemCache.__init__(
             self,
             cache_dir=cache_dir,
@@ -70,7 +69,6 @@ class FileSystemCache(BaseCache, CachelibFileSystemCache):
         kwargs.update(
             dict(
                 threshold=config["CACHE_THRESHOLD"],
-                ignore_errors=config["CACHE_IGNORE_ERRORS"],
             )
         )
         return cls(*args, **kwargs)

--- a/src/flask_caching/backends/memcache.py
+++ b/src/flask_caching/backends/memcache.py
@@ -13,13 +13,13 @@ import re
 
 from cachelib import MemcachedCache as CachelibMemcachedCache
 
-from flask_caching.backends.base import BaseCache
+from flask_caching.backends.base import BaseFactory
 
 
 _test_memcached_key = re.compile(r"[^\x00-\x21\xff]{1,250}$").match
 
 
-class MemcachedCache(BaseCache, CachelibMemcachedCache):
+class MemcachedCache(BaseFactory, CachelibMemcachedCache):
 
     """A cache that uses memcached as backend.
 

--- a/src/flask_caching/backends/nullcache.py
+++ b/src/flask_caching/backends/nullcache.py
@@ -8,10 +8,10 @@
     :copyright: (c) 2010 by Thadeus Burgess.
     :license: BSD, see LICENSE for more details.
 """
-from flask_caching.backends.base import BaseCache
+from cachelib import BaseCache as CachelibBaseCache
 
 
-class NullCache(BaseCache):
+class NullCache(CachelibBaseCache):
     """A cache that doesn't cache. This can be useful for unit testing.
 
     :param default_timeout: a dummy parameter that is ignored but exists

--- a/src/flask_caching/backends/rediscache.py
+++ b/src/flask_caching/backends/rediscache.py
@@ -12,10 +12,10 @@ import pickle
 
 from cachelib import RedisCache as CachelibRedisCache
 
-from flask_caching.backends.base import BaseCache
+from flask_caching.backends.base import BaseFactory
 
 
-class RedisCache(BaseCache, CachelibRedisCache):
+class RedisCache(BaseFactory, CachelibRedisCache):
     """Uses the Redis key-value store as a cache backend.
 
     The first argument can be either a string denoting address of the Redis

--- a/src/flask_caching/backends/simplecache.py
+++ b/src/flask_caching/backends/simplecache.py
@@ -12,13 +12,13 @@ import logging
 
 from cachelib import SimpleCache as CachelibSimpleCache
 
-from flask_caching.backends.base import BaseCache
+from flask_caching.backends.base import BaseFactory
 
 
 logger = logging.getLogger(__name__)
 
 
-class SimpleCache(BaseCache, CachelibSimpleCache):
+class SimpleCache(BaseFactory, CachelibSimpleCache):
     """Simple memory cache for single process environments. This class exists
     mainly for the development server and is not 100% thread safe.  It tries
     to use as many atomic operations as possible and no locks for simplicity
@@ -49,7 +49,6 @@ class SimpleCache(BaseCache, CachelibSimpleCache):
         kwargs.update(
             dict(
                 threshold=config["CACHE_THRESHOLD"],
-                ignore_errors=config["CACHE_IGNORE_ERRORS"],
             )
         )
         return cls(*args, **kwargs)

--- a/src/flask_caching/contrib/googlecloudstoragecache.py
+++ b/src/flask_caching/contrib/googlecloudstoragecache.py
@@ -2,7 +2,9 @@ import datetime
 import json
 import logging
 
-from flask_caching.backends.base import BaseCache
+from cachelib import BaseCache as CachelibBaseCache
+
+from flask_caching.backends.base import BaseFactory
 
 
 logger = logging.getLogger(__name__)
@@ -15,7 +17,7 @@ except ImportError as e:
     raise RuntimeError("no google-cloud-storage module found") from e
 
 
-class GoogleCloudStorageCache(BaseCache):
+class GoogleCloudStorageCache(BaseFactory, CachelibBaseCache):
     """Uses an Google Cloud Storage bucket as a cache backend.
     Note: User-contributed functionality. This project does not guarantee that
     this functionality will be maintained or functional at any given time.

--- a/src/flask_caching/contrib/uwsgicache.py
+++ b/src/flask_caching/contrib/uwsgicache.py
@@ -10,10 +10,10 @@
 """
 from cachelib import UWSGICache as CachelibUWSGICache
 
-from flask_caching.backends.base import BaseCache
+from flask_caching.backends.base import BaseFactory
 
 
-class UWSGICache(BaseCache, CachelibUWSGICache):
+class UWSGICache(BaseFactory, CachelibUWSGICache):
     """Implements the cache using uWSGI's caching framework.
 
     .. note::
@@ -29,7 +29,6 @@ class UWSGICache(BaseCache, CachelibUWSGICache):
     """
 
     def __init__(self, default_timeout=300, cache=""):
-        BaseCache.__init__(self, default_timeout=default_timeout)
         CachelibUWSGICache.__init__(
             self,
             cache=cache,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -73,8 +73,8 @@ def test_cache_unlink_if_not(app):
     assert cache.get("biggerkey2") is None
 
 
-def test_cache_delete_many_ignored(app):
-    cache = Cache(config={"CACHE_TYPE": "simple", "CACHE_IGNORE_ERRORS": True})
+def test_cache_delete_many(app):
+    cache = Cache(config={"CACHE_TYPE": "simple"})
     cache.init_app(app)
 
     cache.set("hi", "hello")

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -217,7 +217,7 @@ def test_set_make_cache_key_property(app, cache):
     def cached_view():
         return str(time.time())
 
-    cached_view.make_cache_key = lambda *args, **kwargs: request.args['foo']
+    cached_view.make_cache_key = lambda *args, **kwargs: request.args["foo"]
 
     tc = app.test_client()
 


### PR DESCRIPTION
We want to upgrade `flask-caching` lib from 1.10.1 to 2.0.2 in apache/superset. PR is https://github.com/apache/superset/pull/22925

But we have a problem with new `delete_many` logic for `RedisCache` in `BaseCache`.
Old `delete_many` logic in 1.10.1 version:
```python
if self.ignore_errors:
    return all([self.delete(key) for key in keys])
return all(self.delete(key) for key in keys)
```

New `delete_many` logic in 2.0.2 version:
```python
deleted_keys = []
for key in keys:
    if self.delete(key):
        deleted_keys.append(key)
    else:
        if not self.ignore_errors:
            break
return deleted_keys
```

In the first case, all cache keys will be deleted, even if some cache keys do not exist.
In the second case, if we have a non-existent first cache key, we will not delete all existing cached keys.

- @northernSage As you mentioned in #307:

> cachelib no longer behaves like this and will always attempt removal of all keys passed into delete_many by default, so I'm considering dropping CACHE_IGNORE_ERRORS and related functionality once the integration is done. This will probably be a major release (2.0.0).

I've removed CACHE_IGNORE_ERRORS flag and now we use `delete_many` from `cachelib`.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
