### PR TITLE
Make cachelib requirement consistent to 0.10.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ from setuptools import setup
 # Metadata goes in setup.cfg. These are here for GitHub's dependency graph.
 setup(
     name="Flask-Caching",
-    install_requires=["cachelib >= 0.9.0, < 0.10.0", "Flask < 3"],
+    install_requires=["cachelib == 0.10.2", "Flask < 3"],
 )


### PR DESCRIPTION
I think the checklist does not apply for such a simple PR.
The requirements for cachelib does not match considering [dev requirements](https://github.com/pallets-eco/flask-caching/blob/d7037dfbaccee828f000ff246dbb3421511f6542/requirements/dev.txt#L19) and setup requirements, modified in this PR.