### PR TITLE
release 2.1.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 Version 2.1.0 
 -------------
 
-Unreleased
+Released 2024-10-08
 
 - fix type signature in ``flask_caching.utils.make_template_fragment_key``. :pr:`430`
 - Added docs and example for make_cache_key

--- a/src/flask_caching/__init__.py
+++ b/src/flask_caching/__init__.py
@@ -33,7 +33,7 @@ from flask_caching.utils import get_id
 from flask_caching.utils import make_template_fragment_key  # noqa: F401
 from flask_caching.utils import wants_args
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Our 2.1.0 release 🎉 

**Change summary**

- fix type signature in ``flask_caching.utils.make_template_fragment_key``. :pr:`430`
- Added docs and example for make_cache_key
- we now support Flask 3