### PR TITLE
Remove unused _get_prefix() method from RedisCache class.

### DIFF
--- a/src/flask_caching/backends/rediscache.py
+++ b/src/flask_caching/backends/rediscache.py
@@ -89,11 +89,6 @@ class RedisCache(BaseCache, CachelibRedisCache):
 
         return new_class
 
-    def _get_prefix(self):
-        return (
-            self.key_prefix if isinstance(self.key_prefix, str) else self.key_prefix()
-        )
-
     def dump_object(self, value):
         """Dumps an object into a string for redis.  By default it serializes
         integers as regular string and pickle dumps everything else.

--- a/tests/test_backend_cache.py
+++ b/tests/test_backend_cache.py
@@ -189,9 +189,9 @@ class TestRedisCache(GenericCacheTests):
         c.clear()
 
     def test_compat(self, c):
-        assert c._write_client.set(c._get_prefix() + "foo", "Awesome")
+        assert c._write_client.set(c.key_prefix + "foo", "Awesome")
         assert c.get("foo") == b"Awesome"
-        assert c._write_client.set(c._get_prefix() + "foo", "42")
+        assert c._write_client.set(c.key_prefix + "foo", "42")
         assert c.get("foo") == 42
 
     def test_empty_host(self):


### PR DESCRIPTION
This removal an addition to this PR : https://github.com/pallets-eco/flask-caching/pull/109.

The main goal is to reintroduce an old behaviour : the possibility to give a function to the key_prefix RedisCache parameter. 
This behaviour is reintroduced in the cachelib library (https://github.com/pallets-eco/cachelib/pull/332).