### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 Version 2.2.0
 -------------
 
-- Drop py37 support
+- Drop python 3.7 support
+- python 3.11 officially supported
+- Fix issue causing `args_to_ignore` to not work with `flask_caching.Cache.memoize` decorator when keyword arguments were used in the decorated function call
 
 
 Version 2.1.0

--- a/src/flask_caching/__init__.py
+++ b/src/flask_caching/__init__.py
@@ -40,7 +40,7 @@ from flask_caching.utils import get_id
 from flask_caching.utils import make_template_fragment_key  # noqa: F401
 from flask_caching.utils import wants_args
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Our 2.2.0 release 🎉 

some house keeping stuff

- added python 3.11 to supported array
- drop python 3.7 (long overdue)
- Fix issue causing `args_to_ignore` to not work with `flask_caching.Cache.memoize` decorator when keyword arguments were used in the decorated function call