### PR TITLE
Release 2.3.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 Version 2.3.0
 -------------
 
-- add indication if cache is used  in the response header.
+Released 2024-05-04
+
 - Added ``response_hit_indication`` flag to ``Cache.cached`` decorator for appending 'hit_cache' headers to responses, indicating cache hits.
 
 

--- a/src/flask_caching/__init__.py
+++ b/src/flask_caching/__init__.py
@@ -40,7 +40,7 @@ from flask_caching.utils import get_id
 from flask_caching.utils import make_template_fragment_key  # noqa: F401
 from flask_caching.utils import wants_args
 
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Our 2.3.0 release 🎉 

- Added ``response_hit_indication`` flag to ``Cache.cached`` decorator for appending 'hit_cache' headers to responses, indicating cache hits.