### PR TITLE
Handle exception on jinja template while having cache failure

### DIFF
--- a/src/flask_caching/jinja2ext.py
+++ b/src/flask_caching/jinja2ext.py
@@ -93,11 +93,22 @@ class CacheExtension(Extension):
 
         #: Delete key if timeout is 'del'
         if timeout == "del":
-            cache.delete(key)
-            return caller()
+            try:
+                cache.delete(key)
+                return caller()
+            except Exception as e:
+                if cache.app.debug:
+                    raise e
+                else:
+                    return caller()
 
-        rv = cache.get(key)
-        if rv is None:
-            rv = caller()
-            cache.set(key, rv, timeout)
-        return rv
+        try:
+            rv = cache.get(key)
+            if rv is None:
+                rv = caller()
+                cache.set(key, rv, timeout)
+        except Exception as e:
+            if cache.app.debug:
+                raise e
+            else:
+                return caller()

--- a/src/flask_caching/jinja2ext.py
+++ b/src/flask_caching/jinja2ext.py
@@ -107,6 +107,7 @@ class CacheExtension(Extension):
             if rv is None:
                 rv = caller()
                 cache.set(key, rv, timeout)
+            return rv
         except Exception as e:
             if cache.app.debug:
                 raise e


### PR DESCRIPTION
Due to #564 , if the debug is false in production, having cache system failure would ruin the whole app.
This is inconsistent compare to the exception handle in the `@memoize` decoration, which is allowed your app continue running even caching system (like redis) is down.

- fixes #564 


Checklist:

- [ x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ x] Add or update relevant docs, in the docs folder and in code.
- [ x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ x] Add `.. versionchanged::` entries in any relevant code docs.
- [ x] Run `pre-commit` hooks and fix any issues.
- [ x] Run `pytest` and `tox`, no tests failed.
