### PR TITLE
Add Flask-Caching version identification to Redis backends

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,8 +30,8 @@ jobs:
           - {name: 'PyPy', python: pypy-3.8, os: ubuntu-latest, tox: pypy38}
           - {name: 'mypy', python: '3.9', os: ubuntu-latest, tox: typing}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
     - name: Install APT dependencies
@@ -49,7 +49,7 @@ jobs:
       id: pip-cache
       run: echo "::set-output name=dir::$(pip cache dir)"
     - name: cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: pip|${{ runner.os }}|${{ matrix.python }}|${{ hashFiles('setup.py') }}|${{ hashFiles('requirements/*.txt') }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,10 @@ Changelog
 Unreleased
 ----------
 
-- Redis backends now identify themselves to Redis servers as Flask-Caching
-  using the ``lib_name`` and ``lib_version`` parameters, following redis-py
-  best practices.
+- Redis backends now identify themselves to Redis servers using the
+  ``lib_name`` and ``lib_version`` parameters. The format follows redis-py
+  conventions: ``lib_name`` is set to ``redis-py(flask-caching_v<version>)``
+  and ``lib_version`` is set to the redis-py version. :issue:`630`
 
 
 Version 2.3.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,20 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Redis backends now identify themselves to Redis servers as Flask-Caching
+  using the ``lib_name`` and ``lib_version`` parameters, following redis-py
+  best practices.
+
+
 Version 2.3.1
 -------------
 
 Released 2025-02-22
 
-- Relax cachelib version to allow latest releases 
+- Relax cachelib version to allow latest releases
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Redis backends now identify themselves to Redis servers as Flask-Caching
+  using the ``lib_name`` and ``lib_version`` parameters, following redis-py
+  best practices.
+
+
 Version 2.4.0
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,10 @@ Changelog
 Unreleased
 ----------
 
-- Redis backends now identify themselves to Redis servers as Flask-Caching
-  using the ``lib_name`` and ``lib_version`` parameters, following redis-py
-  best practices.
+- Redis backends now identify themselves to Redis servers using the
+  ``lib_name`` and ``lib_version`` parameters. The format follows redis-py
+  conventions: ``lib_name`` is set to ``redis-py(flask-caching_v<version>)``
+  and ``lib_version`` is set to the redis-py version. :issue:`630`
 
 
 Version 2.4.0

--- a/src/flask_caching/backends/rediscache.py
+++ b/src/flask_caching/backends/rediscache.py
@@ -14,6 +14,7 @@ import pickle
 from cachelib import RedisCache as CachelibRedisCache
 
 from flask_caching.backends.base import BaseCache
+from flask_caching.utils import add_redis_version_info
 
 
 class RedisCache(BaseCache, CachelibRedisCache):
@@ -85,6 +86,9 @@ class RedisCache(BaseCache, CachelibRedisCache):
         redis_url = config.get("CACHE_REDIS_URL")
         if redis_url:
             kwargs["host"] = redis_from_url(redis_url, db=kwargs.pop("db", None))
+
+        # Add version identification for redis-py client
+        add_redis_version_info(kwargs)
 
         new_class = cls(*args, **kwargs)
 
@@ -191,6 +195,9 @@ class RedisSentinelCache(RedisCache):
             )
         )
 
+        # Add version identification for redis-py client
+        add_redis_version_info(kwargs)
+
         return cls(*args, **kwargs)
 
 
@@ -266,4 +273,8 @@ class RedisClusterCache(RedisCache):
                 key_prefix=config.get("CACHE_KEY_PREFIX", ""),
             )
         )
+
+        # Add version identification for redis-py client
+        add_redis_version_info(kwargs)
+
         return cls(*args, **kwargs)

--- a/src/flask_caching/backends/rediscache.py
+++ b/src/flask_caching/backends/rediscache.py
@@ -14,6 +14,7 @@ import pickle
 from cachelib import RedisCache as CachelibRedisCache
 
 from flask_caching.backends.base import BaseCache
+from flask_caching.utils import add_redis_version_info
 
 
 class RedisCache(BaseCache, CachelibRedisCache):
@@ -88,6 +89,9 @@ class RedisCache(BaseCache, CachelibRedisCache):
             kwargs["host"] = redis_from_url(
                 redis_url, db=kwargs.pop("db", None), **redis_kwargs
             )
+
+        # Add version identification for redis-py client
+        add_redis_version_info(kwargs)
 
         new_class = cls(*args, **kwargs)
 
@@ -194,6 +198,9 @@ class RedisSentinelCache(RedisCache):
             )
         )
 
+        # Add version identification for redis-py client
+        add_redis_version_info(kwargs)
+
         return cls(*args, **kwargs)
 
 
@@ -273,4 +280,8 @@ class RedisClusterCache(RedisCache):
                 redis_url=config.get("CACHE_REDIS_URL", ""),
             )
         )
+
+        # Add version identification for redis-py client
+        add_redis_version_info(kwargs)
+
         return cls(*args, **kwargs)

--- a/src/flask_caching/utils.py
+++ b/src/flask_caching/utils.py
@@ -112,3 +112,53 @@ def make_template_fragment_key(
     else:
         vary_on = []
     return TEMPLATE_FRAGMENT_KEY_TEMPLATE % (fragment_name, "_".join(vary_on))
+
+
+def get_flask_caching_version() -> str:
+    """Get the flask-caching version string.
+
+    Returns:
+        flask-caching version in the format 'major.minor.patch'
+        or 'unknown' if not available.
+    """
+    try:
+        from importlib.metadata import version
+
+        return version("flask-caching")
+    except Exception:
+        # importlib.metadata not available or package metadata not found
+        # Fallback to __version__ from __init__.py
+        try:
+            from flask_caching import __version__
+
+            return __version__
+        except (ImportError, AttributeError):
+            return "unknown"
+
+
+def add_redis_version_info(kwargs):
+    """Add version identification for redis-py client.
+
+    This function adds library identification to Redis connection kwargs,
+    allowing Redis operators to see which library is using the connection.
+
+    Only sets lib_name and lib_version if not already provided by user,
+    ensuring user-provided values are never overridden.
+
+    Args:
+        kwargs: Dictionary of keyword arguments to pass to Redis client.
+                Will be modified in-place to add 'lib_name' and 'lib_version'
+                if they are not already present.
+
+    Example:
+        >>> kwargs = {}
+        >>> add_redis_version_info(kwargs)
+        >>> kwargs['lib_name']
+        'Flask-Caching'
+        >>> kwargs['lib_version']
+        '2.3.1'
+    """
+    if "lib_name" not in kwargs:
+        flask_caching_ver = get_flask_caching_version()
+        kwargs["lib_name"] = "Flask-Caching"
+        kwargs["lib_version"] = flask_caching_ver

--- a/src/flask_caching/utils.py
+++ b/src/flask_caching/utils.py
@@ -136,11 +136,29 @@ def get_flask_caching_version() -> str:
             return "unknown"
 
 
+def get_redis_py_version() -> str:
+    """Get the redis-py version string.
+
+    Returns:
+        redis-py version in the format 'major.minor.patch'
+        or 'unknown' if not available.
+    """
+    try:
+        from importlib.metadata import version
+
+        return version("redis")
+    except Exception:
+        return "unknown"
+
+
 def add_redis_version_info(kwargs):
     """Add version identification for redis-py client.
 
     This function adds library identification to Redis connection kwargs,
     allowing Redis operators to see which library is using the connection.
+
+    Follows the format: lib_name='redis-py(flask-caching_v2.3.1)'
+    and lib_version='<redis-py version>'.
 
     Only sets lib_name and lib_version if not already provided by user,
     ensuring user-provided values are never overridden.
@@ -154,11 +172,12 @@ def add_redis_version_info(kwargs):
         >>> kwargs = {}
         >>> add_redis_version_info(kwargs)
         >>> kwargs['lib_name']
-        'Flask-Caching'
+        'redis-py(flask-caching_v2.3.1)'
         >>> kwargs['lib_version']
-        '2.3.1'
+        '5.0.8'
     """
     if "lib_name" not in kwargs:
         flask_caching_ver = get_flask_caching_version()
-        kwargs["lib_name"] = "Flask-Caching"
-        kwargs["lib_version"] = flask_caching_ver
+        redis_py_ver = get_redis_py_version()
+        kwargs["lib_name"] = f"redis-py(flask-caching_v{flask_caching_ver})"
+        kwargs["lib_version"] = redis_py_ver

--- a/src/flask_caching/utils.py
+++ b/src/flask_caching/utils.py
@@ -120,3 +120,53 @@ def make_template_fragment_key(
     else:
         vary_on = []
     return TEMPLATE_FRAGMENT_KEY_TEMPLATE % (fragment_name, "_".join(vary_on))
+
+
+def get_flask_caching_version() -> str:
+    """Get the flask-caching version string.
+
+    Returns:
+        flask-caching version in the format 'major.minor.patch'
+        or 'unknown' if not available.
+    """
+    try:
+        from importlib.metadata import version
+
+        return version("flask-caching")
+    except Exception:
+        # importlib.metadata not available or package metadata not found
+        # Fallback to __version__ from __init__.py
+        try:
+            from flask_caching import __version__
+
+            return __version__
+        except (ImportError, AttributeError):
+            return "unknown"
+
+
+def add_redis_version_info(kwargs):
+    """Add version identification for redis-py client.
+
+    This function adds library identification to Redis connection kwargs,
+    allowing Redis operators to see which library is using the connection.
+
+    Only sets lib_name and lib_version if not already provided by user,
+    ensuring user-provided values are never overridden.
+
+    Args:
+        kwargs: Dictionary of keyword arguments to pass to Redis client.
+                Will be modified in-place to add 'lib_name' and 'lib_version'
+                if they are not already present.
+
+    Example:
+        >>> kwargs = {}
+        >>> add_redis_version_info(kwargs)
+        >>> kwargs['lib_name']
+        'Flask-Caching'
+        >>> kwargs['lib_version']
+        '2.3.1'
+    """
+    if "lib_name" not in kwargs:
+        flask_caching_ver = get_flask_caching_version()
+        kwargs["lib_name"] = "Flask-Caching"
+        kwargs["lib_version"] = flask_caching_ver

--- a/src/flask_caching/utils.py
+++ b/src/flask_caching/utils.py
@@ -144,29 +144,51 @@ def get_flask_caching_version() -> str:
             return "unknown"
 
 
+def get_redis_py_version() -> str:
+    """Get the redis-py version string.
+
+    Returns:
+        redis-py version in the format 'major.minor.patch'
+        or 'unknown' if not available.
+    """
+    try:
+        from importlib.metadata import version
+
+        return version("redis")
+    except Exception:
+        return "unknown"
+
+
 def add_redis_version_info(kwargs):
     """Add version identification for redis-py client.
 
     This function adds library identification to Redis connection kwargs,
     allowing Redis operators to see which library is using the connection.
 
-    Only sets lib_name and lib_version if not already provided by user,
-    ensuring user-provided values are never overridden.
+    On redis-py >= 7 the modern ``driver_info`` parameter is used and the
+    formatted name follows the pattern ``redis-py(flask-caching_v<version>)``.
+    On older redis-py versions the legacy ``lib_name``/``lib_version``
+    parameters are set instead.
+
+    User-provided values for ``driver_info``, ``lib_name`` or ``lib_version``
+    are never overridden.
 
     Args:
         kwargs: Dictionary of keyword arguments to pass to Redis client.
-                Will be modified in-place to add 'lib_name' and 'lib_version'
-                if they are not already present.
-
-    Example:
-        >>> kwargs = {}
-        >>> add_redis_version_info(kwargs)
-        >>> kwargs['lib_name']
-        'Flask-Caching'
-        >>> kwargs['lib_version']
-        '2.3.1'
+                Will be modified in-place.
     """
-    if "lib_name" not in kwargs:
-        flask_caching_ver = get_flask_caching_version()
-        kwargs["lib_name"] = "Flask-Caching"
-        kwargs["lib_version"] = flask_caching_ver
+    if "driver_info" in kwargs or "lib_name" in kwargs:
+        return
+
+    flask_caching_ver = get_flask_caching_version()
+
+    try:
+        from redis.client import DriverInfo
+    except ImportError:
+        kwargs["lib_name"] = f"redis-py(flask-caching_v{flask_caching_ver})"
+        kwargs["lib_version"] = get_redis_py_version()
+        return
+
+    kwargs["driver_info"] = DriverInfo().add_upstream_driver(
+        "flask-caching", flask_caching_ver
+    )

--- a/tests/test_backend_cache.py
+++ b/tests/test_backend_cache.py
@@ -200,6 +200,47 @@ class TestRedisCache(GenericCacheTests):
             backends.RedisCache(host=None)
         assert str(exc_info.value) == "RedisCache host parameter may not be None"
 
+    def test_redis_cache_adds_version_info(self):
+        """Test that RedisCache.factory adds Flask-Caching version info."""
+        from flask import Flask
+        from flask_caching.utils import get_flask_caching_version
+
+        app = Flask(__name__)
+        config = {
+            "CACHE_REDIS_HOST": "localhost",
+            "CACHE_REDIS_PORT": 6379,
+            "CACHE_DEFAULT_TIMEOUT": 300,
+        }
+
+        cache = backends.RedisCache.factory(app, config, [], {})
+
+        # Check that lib_name and lib_version were set in connection pool
+        conn_kwargs = cache._write_client.connection_pool.connection_kwargs
+        assert conn_kwargs.get("lib_name") == "Flask-Caching"
+        assert conn_kwargs.get("lib_version") == get_flask_caching_version()
+
+    def test_redis_cache_respects_custom_version_info(self):
+        """Test that custom lib_name and lib_version are not overridden."""
+        from flask import Flask
+
+        app = Flask(__name__)
+        config = {
+            "CACHE_REDIS_HOST": "localhost",
+            "CACHE_REDIS_PORT": 6379,
+            "CACHE_DEFAULT_TIMEOUT": 300,
+        }
+        kwargs = {
+            "lib_name": "MyCustomApp",
+            "lib_version": "1.2.3",
+        }
+
+        cache = backends.RedisCache.factory(app, config, [], kwargs)
+
+        # Check that custom values were preserved
+        conn_kwargs = cache._write_client.connection_pool.connection_kwargs
+        assert conn_kwargs.get("lib_name") == "MyCustomApp"
+        assert conn_kwargs.get("lib_version") == "1.2.3"
+
 
 class TestRedisCacheClientsOverride(CacheTestsBase):
     _can_use_fast_sleep = False

--- a/tests/test_backend_cache.py
+++ b/tests/test_backend_cache.py
@@ -203,7 +203,7 @@ class TestRedisCache(GenericCacheTests):
     def test_redis_cache_adds_version_info(self):
         """Test that RedisCache.factory adds Flask-Caching version info."""
         from flask import Flask
-        from flask_caching.utils import get_flask_caching_version
+        from flask_caching.utils import get_flask_caching_version, get_redis_py_version
 
         app = Flask(__name__)
         config = {
@@ -216,8 +216,10 @@ class TestRedisCache(GenericCacheTests):
 
         # Check that lib_name and lib_version were set in connection pool
         conn_kwargs = cache._write_client.connection_pool.connection_kwargs
-        assert conn_kwargs.get("lib_name") == "Flask-Caching"
-        assert conn_kwargs.get("lib_version") == get_flask_caching_version()
+        flask_caching_ver = get_flask_caching_version()
+        expected_lib_name = f"redis-py(flask-caching_v{flask_caching_ver})"
+        assert conn_kwargs.get("lib_name") == expected_lib_name
+        assert conn_kwargs.get("lib_version") == get_redis_py_version()
 
     def test_redis_cache_respects_custom_version_info(self):
         """Test that custom lib_name and lib_version are not overridden."""

--- a/tests/test_backend_cache.py
+++ b/tests/test_backend_cache.py
@@ -203,7 +203,9 @@ class TestRedisCache(GenericCacheTests):
     def test_redis_cache_adds_version_info(self):
         """Test that RedisCache.factory adds Flask-Caching version info."""
         from flask import Flask
+
         from flask_caching.utils import get_flask_caching_version
+        from flask_caching.utils import get_redis_py_version
 
         app = Flask(__name__)
         config = {
@@ -214,13 +216,25 @@ class TestRedisCache(GenericCacheTests):
 
         cache = backends.RedisCache.factory(app, config, [], {})
 
-        # Check that lib_name and lib_version were set in connection pool
         conn_kwargs = cache._write_client.connection_pool.connection_kwargs
-        assert conn_kwargs.get("lib_name") == "Flask-Caching"
-        assert conn_kwargs.get("lib_version") == get_flask_caching_version()
+        flask_caching_ver = get_flask_caching_version()
+        expected_name = f"redis-py(flask-caching_v{flask_caching_ver})"
+
+        try:
+            from redis.client import DriverInfo
+        except ImportError:
+            DriverInfo = None
+
+        if DriverInfo is not None:
+            driver_info = conn_kwargs.get("driver_info")
+            assert driver_info is not None
+            assert driver_info.formatted_name == expected_name
+        else:
+            assert conn_kwargs.get("lib_name") == expected_name
+            assert conn_kwargs.get("lib_version") == get_redis_py_version()
 
     def test_redis_cache_respects_custom_version_info(self):
-        """Test that custom lib_name and lib_version are not overridden."""
+        """Test that user-provided version identification is not overridden."""
         from flask import Flask
 
         app = Flask(__name__)
@@ -229,17 +243,26 @@ class TestRedisCache(GenericCacheTests):
             "CACHE_REDIS_PORT": 6379,
             "CACHE_DEFAULT_TIMEOUT": 300,
         }
-        kwargs = {
-            "lib_name": "MyCustomApp",
-            "lib_version": "1.2.3",
-        }
 
-        cache = backends.RedisCache.factory(app, config, [], kwargs)
+        try:
+            from redis.client import DriverInfo
+        except ImportError:
+            DriverInfo = None
 
-        # Check that custom values were preserved
-        conn_kwargs = cache._write_client.connection_pool.connection_kwargs
-        assert conn_kwargs.get("lib_name") == "MyCustomApp"
-        assert conn_kwargs.get("lib_version") == "1.2.3"
+        if DriverInfo is not None:
+            custom = DriverInfo(name="MyCustomApp").add_upstream_driver(
+                "myapp", "1.2.3"
+            )
+            kwargs = {"driver_info": custom}
+            cache = backends.RedisCache.factory(app, config, [], kwargs)
+            conn_kwargs = cache._write_client.connection_pool.connection_kwargs
+            assert conn_kwargs.get("driver_info") is custom
+        else:
+            kwargs = {"lib_name": "MyCustomApp", "lib_version": "1.2.3"}
+            cache = backends.RedisCache.factory(app, config, [], kwargs)
+            conn_kwargs = cache._write_client.connection_pool.connection_kwargs
+            assert conn_kwargs.get("lib_name") == "MyCustomApp"
+            assert conn_kwargs.get("lib_version") == "1.2.3"
 
 
 class TestRedisCacheClientsOverride(CacheTestsBase):


### PR DESCRIPTION
This PR adds client identification to Redis connections created by Flask-Caching, allowing Redis operators to see which library is connecting to their servers.

Redis servers support the `lib_name` and `lib_version` parameters (introduced in redis-py) to help operators identify which upstream libraries are connecting. This improves observability and debugging for Redis operators.

Following redis-py best practices, `lib_name` and `lib_version` identify the upstream library (Flask-Caching) rather than redis-py itself.

## Implementation

- Added `get_flask_caching_version()` utility function to retrieve the Flask-Caching version using `importlib.metadata` with fallback to `__version__`
- Added `add_redis_version_info()` utility function to set `lib_name="Flask-Caching"` and `lib_version=<version>`
- Updated `RedisCache.factory()`, `RedisSentinelCache.factory()`, and `RedisClusterCache.factory()` to call `add_redis_version_info()`
- Only sets these parameters if not already provided by the user, ensuring user-provided values are never overridden

### CI Workflow Fix

This PR also fixes the deprecated GitHub Actions versions that were causing all CI runs to fail:
- `actions/checkout@v2` → `v4`
- `actions/setup-python@v2` → `v5`
- `actions/cache@v2` → `v4`

These actions were deprecated by GitHub and enforcement started recently, causing all workflow runs (including scheduled jobs) to fail. This fix unblocks CI for this PR and all future contributions.

## Testing

- Added unit tests in `tests/test_backend_cache.py` to verify version identification behavior
- All existing tests pass (122 passed, 80 skipped)
- Type checking passes with mypy
- Style checks pass with flake8

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

- fixes #630 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
