### PR TITLE
allow setting `hash_method` for FileSystemCache when init cache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Unreleased
   ``after_request`` function to the app on every request.
 - Fix ``__caching_id__`` never being usable. ``@memoize`` silently ignored that
   and ran the function uncached.
+- Add ``CACHE_FILE_HASH_METHOD`` config option to ``FileSystemCache`` to allow
+  using a different hash function for cache keys. :pr:`660`
 
 
 Version 2.4.1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -456,6 +456,8 @@ The following configuration values exist for Flask-Caching:
                                 e.g. host1:port1,host2:port2,host3:port3 . Used only for RedisClusterCache.
 ``CACHE_DIR``                   Directory to store cache. Used only for
                                 FileSystemCache.
+``CACHE_FILE_HASH_METHOD``      hash_method used for hashing cache keys. Used only for
+                                FileSystemCache.
 ``CACHE_REDIS_URL``             URL to connect to Redis server.
                                 Example ``redis://user:password@localhost:6379/2``. Supports
                                 protocols ``redis://``, ``rediss://`` (redis over TLS) and

--- a/src/flask_caching/__init__.py
+++ b/src/flask_caching/__init__.py
@@ -210,6 +210,7 @@ class Cache:
         config.setdefault("CACHE_KEY_PREFIX", "flask_cache_")
         config.setdefault("CACHE_MEMCACHED_SERVERS", None)
         config.setdefault("CACHE_DIR", None)
+        config.setdefault("CACHE_FILE_HASH_METHOD", hashlib.sha256)
         config.setdefault("CACHE_OPTIONS", None)
         config.setdefault("CACHE_ARGS", [])
         config.setdefault("CACHE_TYPE", "null")

--- a/src/flask_caching/backends/filesystemcache.py
+++ b/src/flask_caching/backends/filesystemcache.py
@@ -35,7 +35,7 @@ class FileSystemCache(BaseCache, CachelibFileSystemCache):
                             specified on :meth:`~BaseCache.set`. A timeout of
                             0 indicates that the cache never expires.
     :param mode: the file mode wanted for the cache files, default 0600
-    :param hash_method: Default hashlib.md5. The hash method used to
+    :param hash_method: Default hashlib.sha256. The hash method used to
                         generate the filename for cached results.
     :param ignore_errors: If set to ``True`` the :meth:`~BaseCache.delete_many`
                           method will ignore any errors that occurred during the
@@ -50,7 +50,7 @@ class FileSystemCache(BaseCache, CachelibFileSystemCache):
         threshold: int = 500,
         default_timeout: int = 300,
         mode: int = 0o600,
-        hash_method: Any = hashlib.md5,
+        hash_method: Any = hashlib.sha256,
         ignore_errors: bool = False,
     ) -> None:
         BaseCache.__init__(self, default_timeout=default_timeout)
@@ -78,6 +78,7 @@ class FileSystemCache(BaseCache, CachelibFileSystemCache):
             dict(
                 threshold=config["CACHE_THRESHOLD"],
                 ignore_errors=config["CACHE_IGNORE_ERRORS"],
+                hash_method=config["CACHE_FILE_HASH_METHOD"],
             )
         )
         return cls(*args, **kwargs)


### PR DESCRIPTION
closes https://github.com/pallets-eco/flask-caching/issues/211

Now you can simply set the desired hash method when initializing the cache.
Also updated default hash method to a FIPs compliant method.
```py
import hashlib

from flask import Flask

from flask_caching import Cache

app = Flask(__name__)
cache_instance = Cache(
    app,
    config={
        "CACHE_TYPE": "filesystem",
        "CACHE_DIR": "./flask_caching_test",
        "CACHE_HASH_METHOD": hashlib.sha256,
    },
)


@app.route("/")
@cache_instance.cached()
def index():
    return "hey world"


if __name__ == "__main__":
    app.run(debug=True, host="0.0.0.0", port=5001)
```