### PR TITLE
Include key_prefix in query string cache keys

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Version 2.5.0
 
 Unreleased
 
+- Include ``key_prefix`` when building ``@cached(query_string=True)`` cache
+  keys. :issue:`302`
 - Use ``hashlib.sha256`` instead of ``hashlib.md5`` for hashing the cache keys.
   This changes the generated keys, so entries cached by an earlier version become
   obsolete. If you wish to still use hashlib.md5 set the config

--- a/src/flask_caching/__init__.py
+++ b/src/flask_caching/__init__.py
@@ -449,6 +449,9 @@ class Cache:
                              _make_cache_key_query_string() for more
                              details.
 
+        .. versionchanged:: 2.5.0
+            Include ``key_prefix`` when building query string cache keys.
+
         :param hash_method: Default None. If None will use the value set by
                             ``CACHE_HASH_METHOD``, which defaults to
                             ``hashlib.sha256``. The hash method used to
@@ -611,9 +614,14 @@ class Cache:
 
                 cache_hash = str(cache_hash.hexdigest())
 
-                cache_key = request.path + cache_hash
+                if callable(key_prefix):
+                    cache_key = key_prefix()
+                elif "%s" in key_prefix:
+                    cache_key = key_prefix % request.path
+                else:
+                    cache_key = key_prefix
 
-                return cache_key
+                return cache_key + cache_hash
 
             def _make_cache_key(
                 args: tuple[Any, ...], kwargs: dict[str, Any], use_request: bool

--- a/tests/test_hash_method.py
+++ b/tests/test_hash_method.py
@@ -6,9 +6,11 @@ import pytest
 from flask_caching import Cache
 
 
-def _query_string_key(path, args_as_sorted_tuple, hash_method):
+def _query_string_key(path, args_as_sorted_tuple, hash_method, key_prefix="view/%s"):
     """Rebuild the key that ``cached(query_string=True)`` produces."""
-    return path + hash_method(str(args_as_sorted_tuple).encode()).hexdigest()
+    return (key_prefix % path) + hash_method(
+        str(args_as_sorted_tuple).encode()
+    ).hexdigest()
 
 
 def test_default_hash_method_is_sha256(app):
@@ -22,6 +24,18 @@ def test_default_hash_method_is_sha256(app):
     with app.test_request_context("/works?a=1&b=2"):
         assert view.make_cache_key() == _query_string_key(
             "/works", (("a", "1"), ("b", "2")), hashlib.sha256
+        )
+
+
+def test_query_string_key_includes_key_prefix(app, cache):
+    @app.route("/works")
+    @cache.cached(query_string=True, key_prefix="custom/%s")
+    def view():
+        return "value"
+
+    with app.test_request_context("/works?a=1"):
+        assert view.make_cache_key() == _query_string_key(
+            "/works", (("a", "1"),), hashlib.sha256, key_prefix="custom/%s"
         )
 
 


### PR DESCRIPTION
`@cache.cached(query_string=True)` previously built cache keys from the
request path and query hash alone, silently ignoring `key_prefix`. This
change resolves string and callable prefixes before appending the stable
query hash, and adds regression coverage for a custom path prefix.

Fixes #302

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
