### PR TITLE
Include HTTP method in default cache keys

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Unreleased
 - Send Signals for cache hits and misses. :pr:`#237` and :pr:`667`
 - Include ``key_prefix`` when building ``@cached(query_string=True)`` cache
   keys. :issue:`302`
+- Include the HTTP method in default request-derived ``@cached`` keys, preventing
+  ``HEAD`` and ``GET`` responses from sharing a cache entry. Existing entries
+  expire according to their configured timeout; entries without a timeout must
+  be removed manually. :issue:`270`
 - Use ``hashlib.sha256`` instead of ``hashlib.md5`` for hashing the cache keys.
   This changes the generated keys, so entries cached by an earlier version become
   obsolete. If you wish to still use hashlib.md5 set the config

--- a/src/flask_caching/__init__.py
+++ b/src/flask_caching/__init__.py
@@ -489,6 +489,9 @@ class Cache:
         :param response_hit_indication: Default False.
                              If True, it will add to response header field 'hit_cache'
                              if used cache.
+
+        .. versionchanged:: 2.5
+            Default request-derived cache keys include the HTTP method.
         """
 
         def decorator(f: Callable[P, R]) -> _CachedFunction[P, R]:
@@ -636,7 +639,7 @@ class Cache:
                 if callable(key_prefix):
                     cache_key = key_prefix()
                 elif "%s" in key_prefix:
-                    cache_key = key_prefix % request.path
+                    cache_key = f"{request.method}:{key_prefix % request.path}"
                 else:
                     cache_key = key_prefix
 
@@ -656,6 +659,7 @@ class Cache:
                             cache_key = key_prefix % request.path
                         else:
                             cache_key = key_prefix % url_for(f.__name__, **kwargs)
+                        cache_key = f"{request.method}:{cache_key}"
                     else:
                         cache_key = key_prefix
 

--- a/tests/test_hash_method.py
+++ b/tests/test_hash_method.py
@@ -2,15 +2,36 @@ import hashlib
 import random
 
 import pytest
+from flask import request
 
 from flask_caching import Cache
 
 
 def _query_string_key(path, args_as_sorted_tuple, hash_method, key_prefix="view/%s"):
     """Rebuild the key that ``cached(query_string=True)`` produces."""
-    return (key_prefix % path) + hash_method(
-        str(args_as_sorted_tuple).encode()
-    ).hexdigest()
+    return (
+        "GET:"
+        + (key_prefix % path)
+        + hash_method(str(args_as_sorted_tuple).encode()).hexdigest()
+    )
+
+
+@pytest.mark.parametrize("query_string", [False, True])
+def test_cached_separates_http_methods(app, query_string):
+    cache = Cache(app)
+    calls = []
+
+    @app.route("/method", methods=["GET", "HEAD"])
+    @cache.cached(query_string=query_string)
+    def view():
+        calls.append(request.method)
+        return request.method
+
+    client = app.test_client()
+    client.head("/method?item=1")
+    assert client.get("/method?item=1").get_data(as_text=True) == "GET"
+    assert client.get("/method?item=1").get_data(as_text=True) == "GET"
+    assert calls == ["HEAD", "GET"]
 
 
 def test_default_hash_method_is_sha256(app):


### PR DESCRIPTION
Default request-derived cache keys now include the HTTP method. This prevents a cached `HEAD` result from being served to a later `GET` request while leaving explicit `make_cache_key` callbacks and fixed key prefixes unchanged.

The regression test covers both ordinary path keys and `query_string=True` keys. The full local suite passed with 222 tests and 3 skips, and all pre-commit hooks passed.

- fixes #270

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed. (`pytest` passed; the full tox matrix was not run locally.)
