### PR TITLE
docs: fix grammar and typos in jinja2ext and utils

### DIFF
--- a/src/flask_caching/jinja2ext.py
+++ b/src/flask_caching/jinja2ext.py
@@ -21,7 +21,7 @@ Set the timeout to ``None`` for no timeout, but with custom keys::
     ...
     {% endcache %}
 
-Set timeout to ``del`` to delete cached value::
+Set the timeout to ``del`` to delete the cached value::
 
     {% cache 'del' key1 %}
     ...
@@ -65,7 +65,7 @@ class CacheExtension(Extension):
 
         #: Parse fragment name
         #: Grab the fragment name if it exists
-        #: otherwise, default to the old method of using the templates
+        #: otherwise, default to the old method of using the template's
         #: lineno to maintain backwards compatibility.
         if parser.stream.skip_if("comma"):
             args.append(parser.parse_expression())

--- a/src/flask_caching/utils.py
+++ b/src/flask_caching/utils.py
@@ -62,7 +62,7 @@ def get_id(obj: Any) -> str:
 def function_namespace(
     f: Callable[..., Any], args: Any = None
 ) -> tuple[str, str | None]:
-    """Attempts to returns unique namespace for function"""
+    """Attempts to return a unique namespace for the function."""
     m_args = get_arg_names(f)
 
     instance_token = None


### PR DESCRIPTION
### Summary
- Fix typo in `jinja2ext.py` (`using the templates lineno` -> `using the template's lineno`).
- Improve grammar in `function_namespace` docstring in `utils.py` (`Attempts to returns unique namespace` -> `Attempts to return a unique namespace for the function`).